### PR TITLE
Workaround 2 FPC compilation problems, and a memory leak at LoadFromJSON

### DIFF
--- a/src/PasGLTF.pas
+++ b/src/PasGLTF.pas
@@ -4661,6 +4661,7 @@ var GLBHeader:TGLBHeader;
 var RawJSONRawByteString:TPasJSONRawByteString;
     ChunkHeader:TChunkHeader;
     Stream:TMemoryStream;
+    Parsed:TPasJSONItem;
 begin
  if not (assigned(aStream) and (aStream.Size>=GLBHeaderSize)) then begin
   raise EPasGLTFInvalidDocument.Create('Invalid GLB document');
@@ -4689,7 +4690,10 @@ begin
  RawJSONRawByteString:='';
  SetLength(RawJSONRawByteString,GLBHeader.JSONChunkHeader.ChunkLength);
  aStream.ReadBuffer(RawJSONRawByteString[1],length(RawJSONRawByteString));
- LoadFromJSON(TPasJSON.Parse(RawJSONRawByteString,[],TPasJSONEncoding.UTF8));
+ Parsed := TPasJSON.Parse(RawJSONRawByteString,[],TPasJSONEncoding.UTF8);
+ try
+  LoadFromJSON(Parsed);
+ finally FreeAndNil(Parsed) end;
  if aStream.Position<aStream.Size then begin
   if aStream.Read(ChunkHeader,SizeOf(TChunkHeader))<>SizeOf(ChunkHeader) then begin
    raise EPasGLTFInvalidDocument.Create('Invalid GLB document');
@@ -4711,6 +4715,7 @@ end;
 
 procedure TPasGLTF.TDocument.LoadFromStream(const aStream:TStream);
 var FirstFourBytes:array[0..3] of TPasGLTFUInt8;
+    Parsed:TPasJSONItem;
 begin
  aStream.ReadBuffer(FirstFourBytes,SizeOf(FirstFourBytes));
  aStream.Seek(-SizeOf(FirstFourBytes),soCurrent);
@@ -4720,7 +4725,10 @@ begin
     (FirstFourBytes[3]=ord('F')) then begin
   LoadFromBinary(aStream);
  end else begin
-  LoadFromJSON(TPasJSON.Parse(aStream,[],TPasJSONEncoding.AutomaticDetection));
+  Parsed := TPasJSON.Parse(aStream,[],TPasJSONEncoding.AutomaticDetection);
+  try
+   LoadFromJSON(Parsed);
+  finally FreeAndNil(Parsed) end;
  end;
 end;
 

--- a/src/PasGLTF.pas
+++ b/src/PasGLTF.pas
@@ -929,24 +929,28 @@ type PPPasGLTFInt8=^PPasGLTFInt8;
                    TChannels=TPasGLTFObjectList<TChannel>;
                    TSampler=class(TBaseExtensionsExtrasObject)
                     public
-                     type TType=
+                     { This is called TSamplerType, not TType,
+                       to workaround FPC problems (when generating debug info):
+                       PasGLTF.pas(5785,1) Error: Asm: Duplicate label DBG_$PASGLTF_$$_TTYPE
+                       PasGLTF.pas(5785,1) Error: Asm: Duplicate label DBGREF_$PASGLTF_$$_TTYPE }
+                     type TSamplerType=
                            (
                             Linear=0,
                             Step=1,
                             CubicSpline=2
                            );
-                           PType=^TType;
+                           PSamplerType=^TSamplerType;
                     private
                      fInput:TPasGLTFSizeInt;
                      fOutput:TPasGLTFSizeInt;
-                     fInterpolation:TType;
+                     fInterpolation:TSamplerType;
                     public
                      constructor Create(const aDocument:TDocument); override;
                      destructor Destroy; override;
                     published
                      property Input:TPasGLTFSizeInt read fInput write fInput default -1;
                      property Output:TPasGLTFSizeInt read fOutput write fOutput default -1;
-                     property Interpolation:TType read fInterpolation write fInterpolation default TType.Linear;
+                     property Interpolation:TSamplerType read fInterpolation write fInterpolation default TSamplerType.Linear;
                    end;
                    TSamplers=TPasGLTFObjectList<TSampler>;
              private
@@ -1037,7 +1041,11 @@ type PPPasGLTFInt8=^PPasGLTFInt8;
             TBufferViews=TPasGLTFObjectList<TBufferView>;
             TCamera=class(TBaseExtensionsExtrasObject)
              public
-              type TType=
+              { This is called TCameraType, not TType,
+                to workaround FPC problems (when generating debug info):
+                PasGLTF.pas(5785,1) Error: Asm: Duplicate label DBG_$PASGLTF_$$_TTYPE
+                PasGLTF.pas(5785,1) Error: Asm: Duplicate label DBGREF_$PASGLTF_$$_TTYPE }
+              type TCameraType=
                     (
                      None=0,
                      Orthographic=1,
@@ -1078,7 +1086,7 @@ type PPPasGLTFInt8=^PPasGLTFInt8;
                      property Empty:boolean read fEmpty;
                    end;
              private
-              fType:TType;
+              fType:TCameraType;
               fOrthographic:TOrthographic;
               fPerspective:TPerspective;
               fName:TPasGLTFUTF8String;
@@ -1086,7 +1094,7 @@ type PPPasGLTFInt8=^PPasGLTFInt8;
               constructor Create(const aDocument:TDocument); override;
               destructor Destroy; override;
              published
-              property Type_:TType read fType write fType;
+              property Type_:TCameraType read fType write fType;
               property Orthographic:TOrthographic read fOrthographic;
               property Perspective:TPerspective read fPerspective;
               property Name:TPasGLTFUTF8String read fName write fName;
@@ -3051,7 +3059,7 @@ begin
  inherited Create(aDocument);
  fInput:=-1;
  fOutput:=-1;
- fInterpolation:=TType.Linear;
+ fInterpolation:=TSamplerType.Linear;
 end;
 
 destructor TPasGLTF.TAnimation.TSampler.Destroy;
@@ -3285,7 +3293,7 @@ end;
 constructor TPasGLTF.TCamera.Create(const aDocument:TDocument);
 begin
  inherited Create(aDocument);
- fType:=TType.None;
+ fType:=TCameraType.None;
  fOrthographic:=TOrthographic.Create(fDocument);
  fPerspective:=TPerspective.Create(fDocument);
 end;
@@ -3883,11 +3891,11 @@ procedure TPasGLTF.TDocument.LoadFromJSON(const aJSONRootItem:TPasJSONItem);
          end;
          Interpolation:=TPasJSON.GetString(InterpolationItem,'NONE');
          if Interpolation='LINEAR' then begin
-          Sampler.fInterpolation:=TAnimation.TSampler.TType.Linear;
+          Sampler.fInterpolation:=TAnimation.TSampler.TSamplerType.Linear;
          end else if Interpolation='STEP' then begin
-          Sampler.fInterpolation:=TAnimation.TSampler.TType.Step;
+          Sampler.fInterpolation:=TAnimation.TSampler.TSamplerType.Step;
          end else if Interpolation='CUBICSPLINE' then begin
-          Sampler.fInterpolation:=TAnimation.TSampler.TType.CubicSpline;
+          Sampler.fInterpolation:=TAnimation.TSampler.TSamplerType.CubicSpline;
          end else begin
           raise EPasGLTFInvalidDocument.Create('Invalid GLTF document');
          end;
@@ -4007,15 +4015,15 @@ procedure TPasGLTF.TDocument.LoadFromJSON(const aJSONRootItem:TPasJSONItem);
     begin
      Type_:=TPasJSON.GetString(Required(JSONObject.Properties['type'],'type'),'none');
      if Type_='orthographic' then begin
-      result.fType:=TCamera.TType.Orthographic;
+      result.fType:=TCamera.TCameraType.Orthographic;
      end else if Type_='perspective' then begin
-      result.fType:=TCamera.TType.Perspective;
+      result.fType:=TCamera.TCameraType.Perspective;
      end else begin
       raise EPasGLTFInvalidDocument.Create('Invalid GLTF document');
      end;
     end;
     case result.fType of
-     TCamera.TType.Orthographic:begin
+     TCamera.TCameraType.Orthographic:begin
       JSONItem:=JSONObject.Properties['orthographic'];
       if not (assigned(JSONItem) and (JSONItem is TPasJSONItemObject)) then begin
        raise EPasGLTFInvalidDocument.Create('Invalid GLTF document');
@@ -4026,7 +4034,7 @@ procedure TPasGLTF.TDocument.LoadFromJSON(const aJSONRootItem:TPasJSONItem);
       result.fOrthographic.fZNear:=TPasJSON.GetNumber(Required(TPasJSONItemObject(JSONItem).Properties['znear'],'znear'),result.fOrthographic.fZNear);
       result.fOrthographic.fZFar:=TPasJSON.GetNumber(Required(TPasJSONItemObject(JSONItem).Properties['zfar'],'zfar'),result.fOrthographic.fZFar);
      end;
-     TCamera.TType.Perspective:begin
+     TCamera.TCameraType.Perspective:begin
       JSONItem:=JSONObject.Properties['perspective'];
       if not (assigned(JSONItem) and (JSONItem is TPasJSONItemObject)) then begin
        raise EPasGLTFInvalidDocument.Create('Invalid GLTF document');
@@ -4906,13 +4914,13 @@ function TPasGLTF.TDocument.SaveToJSON(const aFormatted:boolean=false):TPasJSONR
          JSONObject.Add('output',TPasJSONItemNumber.Create(Sampler.fOutput));
         end;
         case Sampler.fInterpolation of
-         TPasGLTF.TAnimation.TSampler.TType.Linear:begin
+         TPasGLTF.TAnimation.TSampler.TSamplerType.Linear:begin
           JSONObject.Add('interpolation',TPasJSONItemString.Create('LINEAR'));
          end;
-         TPasGLTF.TAnimation.TSampler.TType.Step:begin
+         TPasGLTF.TAnimation.TSampler.TSamplerType.Step:begin
           JSONObject.Add('interpolation',TPasJSONItemString.Create('STEP'));
          end;
-         TPasGLTF.TAnimation.TSampler.TType.CubicSpline:begin
+         TPasGLTF.TAnimation.TSampler.TSamplerType.CubicSpline:begin
           JSONObject.Add('interpolation',TPasJSONItemString.Create('CUBICSPLINE'));
          end;
          else begin
@@ -5042,7 +5050,7 @@ function TPasGLTF.TDocument.SaveToJSON(const aFormatted:boolean=false):TPasJSONR
      result.Add('name',TPasJSONItemString.Create(aObject.fName));
     end;
     case aObject.Type_ of
-     TPasGLTF.TCamera.TType.Orthographic:begin
+     TPasGLTF.TCamera.TCameraType.Orthographic:begin
       result.Add('type',TPasJSONItemString.Create('orthographic'));
       if not aObject.Orthographic.Empty then begin
        JSONObject:=TPasJSONItemObject.Create;
@@ -5065,7 +5073,7 @@ function TPasGLTF.TDocument.SaveToJSON(const aFormatted:boolean=false):TPasJSONR
        end;
       end;
      end;
-     TPasGLTF.TCamera.TType.Perspective:begin
+     TPasGLTF.TCamera.TCameraType.Perspective:begin
       result.Add('type',TPasJSONItemString.Create('perspective'));
       if not aObject.Perspective.Empty then begin
        JSONObject:=TPasJSONItemObject.Create;

--- a/src/PasGLTF.pas
+++ b/src/PasGLTF.pas
@@ -1890,6 +1890,7 @@ end;
 
 procedure TPasGLTFObjectList<T>.Insert(const pIndex:TPasGLTFSizeInt;const pItem:T);
 var OldCount:TPasGLTFSizeInt;
+    MoveSrc, MoveDst: Pointer;
 begin
  if pIndex>=0 then begin
   OldCount:=fCount;
@@ -1906,7 +1907,12 @@ begin
    FillChar(fItems[OldCount],(fCount-OldCount)*SizeOf(T),#0);
   end;
   if pIndex<OldCount then begin
-   System.Move(fItems[pIndex],fItems[pIndex+1],(OldCount-pIndex)*SizeOf(T));
+   { Use MoveSrc/Dst to workaround FPC 3.3.1 error:
+     Error: Incompatible type for arg no. 1: Got "$gendef124", expected "<Formal type>"
+     (FPC 3.3.1-r40366 [2018/11/24], on Linux/x86_64). }
+   MoveSrc := @(fItems[pIndex]);
+   MoveDst := @(fItems[pIndex+1]);
+   System.Move(MoveSrc^, MoveDst^, (OldCount-pIndex)*SizeOf(T));
    FillChar(fItems[pIndex],SizeOf(T),#0);
   end;
   fItems[pIndex]:=pItem;
@@ -1915,6 +1921,7 @@ end;
 
 procedure TPasGLTFObjectList<T>.Delete(const pIndex:TPasGLTFSizeInt);
 var Old:T;
+    MoveSrc, MoveDst: Pointer;
 begin
  if (pIndex<0) or (pIndex>=fCount) then begin
   raise ERangeError.Create('Out of index range');
@@ -1923,7 +1930,12 @@ begin
  dec(fCount);
  FillChar(fItems[pIndex],SizeOf(T),#0);
  if pIndex<>fCount then begin
-  System.Move(fItems[pIndex+1],fItems[pIndex],(fCount-pIndex)*SizeOf(T));
+  { Use MoveSrc/Dst to workaround FPC 3.3.1 error:
+    Error: Incompatible type for arg no. 1: Got "$gendef124", expected "<Formal type>"
+    (FPC 3.3.1-r40366 [2018/11/24], on Linux/x86_64). }
+  MoveSrc := @(fItems[pIndex+1]);
+  MoveDst := @(fItems[pIndex]);
+  System.Move(MoveSrc, MoveDst, (fCount-pIndex)*SizeOf(T));
   FillChar(fItems[fCount],SizeOf(T),#0);
  end;
  if fCount<(fAllocated shr 1) then begin

--- a/src/viewer/UnitGLTFOpenGL.pas
+++ b/src/viewer/UnitGLTFOpenGL.pas
@@ -1101,13 +1101,13 @@ procedure TGLTFOpenGL.LoadFromDocument(const aDocument:TPasGLTF.TDocument);
     if (SourceAnimationChannel.Sampler>=0) and (SourceAnimationChannel.Sampler<SourceAnimation.Samplers.Count) then begin
      SourceAnimationSampler:=SourceAnimation.Samplers[SourceAnimationChannel.Sampler];
      case SourceAnimationSampler.Interpolation of
-      TPasGLTF.TAnimation.TSampler.TType.Linear:begin
+      TPasGLTF.TAnimation.TSampler.TSamplerType.Linear:begin
        DestinationAnimationChannel^.Interpolation:=TAnimation.TChannel.TInterpolation.Linear;
       end;
-      TPasGLTF.TAnimation.TSampler.TType.Step:begin
+      TPasGLTF.TAnimation.TSampler.TSamplerType.Step:begin
        DestinationAnimationChannel^.Interpolation:=TAnimation.TChannel.TInterpolation.Step;
       end;
-      TPasGLTF.TAnimation.TSampler.TType.CubicSpline:begin
+      TPasGLTF.TAnimation.TSampler.TSamplerType.CubicSpline:begin
        DestinationAnimationChannel^.Interpolation:=TAnimation.TChannel.TInterpolation.CubicSpline;
       end;
       else begin


### PR DESCRIPTION
Hi,

First of all, thanks for developing PasGLTF ! Great job ! I decided to use it as a basis for reading glTF in _Castle Game Engine_. We use PasGLTF unit and convert glTF to an X3D scene graph, which is something that _Castle Game Engine_ can process and display. If you're interested, the complete unit in Castle Game Engine that uses PasGLTF is in here: https://github.com/castle-engine/castle-engine/blob/master/src/x3d/x3dloadinternalgltf.pas . I will announce news about it soon.

I found some small issues in PasGLTF that I managed to fix :)

1. Compilling with FPC 3.0.4 (last stable release) with debug information results in FPC errors:

```
$ fpc -g PasGLTF.pas
Free Pascal Compiler version 3.0.4-r37149 [2018/11/24] for x86_64
Copyright (c) 1993-2017 by Florian Klaempfl and others
Target OS: Linux for x86-64
Compiling PasGLTF.pas
PasGLTF.pas(1953,1) Error: Asm: Duplicate label DBG_$PASGLTF_$$_TTYPE
PasGLTF.pas(1953,1) Error: Asm: Duplicate label DBGREF_$PASGLTF_$$_TTYPE
PasGLTF.pas(1953,1) Error: Asm: Duplicate label DBG_$PASGLTF_$$_TTYPE
PasGLTF.pas(1953,1) Error: Asm: Duplicate label DBGREF_$PASGLTF_$$_TTYPE
PasGLTF.pas(1953,1) Fatal: There were 4 errors compiling module, stopping
```

Looks like FPC doesn't handle the fact that you have

- `TPasGLTF.TAccessor.TType`,
- `TPasGLTF.TSampler.TType`,
- `TPasGLTF.TCamera.TType`.

I workarounded it by renaming
- `TPasGLTF.TSampler.TType` -> `TPasGLTF.TSampler.TSamplerType`,
- `TPasGLTF.TCamera.TType` -> `TPasGLTF.TCamera.TCameraType`.

It looks uglier of course (using the name `TSamplerType` within `TSampler` seems unnecessary), but at least it compiles with FPC with debug information now.

WARNING: This workaround *does* change the public PasGLTF API. If any code is using the `TSampler.TType` or `TCamera.TType`, it will have to be adjusted now. I have adjusted the included viewer such that it compiles.

2. Compiling with recent FPC 3.3.1, reveals additional problem of FPC 3.3.1:

```
$ fpc PasGLTF.pas
Free Pascal Compiler version 3.3.1-r40366 [2018/11/24] for x86_64
Copyright (c) 1993-2018 by Florian Klaempfl and others
Target OS: Linux for x86-64
Compiling PasGLTF.pas
Compiling PasJSON.pas
Compiling PasDblStrUtils.pas
PasGLTF.pas(1901,30) Error: Incompatible type for arg no. 1: Got "$gendef124", expected "<Formal type>"
PasGLTF.pas(1918,31) Error: Incompatible type for arg no. 1: Got "$gendef124", expected "<Formal type>"
PasGLTF.pas(5772) Fatal: There were 2 errors compiling module, stopping
```

They are around two `System.Move(@fItems[...], @fItems[...], ...)` calls. I workaround them using MoveSrc, MoveDst variables.

3. There is a memory leak. To reproduce, you can use a minimal program like attached `test_gltf_read.lpr`, compile it with -gh (HeapTrc unit from FPC).

[test_gltf_read.lpr.txt](https://github.com/BeRo1985/pasgltf/files/2705697/test_gltf_read.lpr.txt)


```
$ fpc -gl -gh test_gltf_read.lpr
...
$ ./test_gltf_read ~/glTF-Sample-Models/2.0/Box/glTF/Box.gltf
Heap dump by heaptrc unit
777 memory blocks allocated : 106058/108168
509 memory blocks freed     : 98480/100368
268 unfreed memory blocks : 7578
True heap size : 557056
True free heap : 507424
Should be : 514952
Call trace for block $00007F75359F3280 size 24
  $00000000004AA8D8
  $00000000004AC740
....
```

The reason is that you call `LoadFromJSON(TPasJSON.Parse(...))`, and `TPasJSON.Parse` creates a new instance of TPasJSONItem. But it is never freed. `LoadFromJSON` doesn't free it.
